### PR TITLE
Initialize project and resolve application icon conflict

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,4 +1,0 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="32" height="32" rx="8" fill="#EAB308"/>
-  <text x="16" y="23" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Display', sans-serif" font-size="20" font-weight="700" fill="#000000" text-anchor="middle">N</text>
-</svg>


### PR DESCRIPTION
- Imported initial codebase from GitHub repository.
- Removed redundant `icon.svg` from the app directory to resolve metadata conflicts and ensure correct icon rendering.

[v0 Session](https://v0.app/chat/TkO4jhwGBzZ)